### PR TITLE
add: call `hasCredential` during `isValidSkill` to ensure the user has the credential they want to give out

### DIFF
--- a/recbot/app/api/fname/route.ts
+++ b/recbot/app/api/fname/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { ICEBREAKER_API_URL } from '@/app/lib/utils';
+
+export async function GET(request: NextRequest) {
+  try {
+    const fname = request.nextUrl.searchParams.get('fname');
+    if (!fname) {
+      throw new Error('fname is required');
+    }
+
+    const response = await fetch(`${ICEBREAKER_API_URL}/api/v1/fname/${fname}`);
+    if (!response.ok) {
+      throw new Error('Error fetching data from Icebreaker API');
+    }
+
+    const data = await response.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Error fetching data from Icebreaker API', error);
+    return new NextResponse('Error fetching data from Icebreaker API', { status: 500 });
+  }
+}

--- a/recbot/app/lib/types.d.ts
+++ b/recbot/app/lib/types.d.ts
@@ -2,6 +2,58 @@
 
 import { type User } from '@neynar/nodejs-sdk/build/neynar-api/v2';
 
+export type IcebreakerUser = {
+  profileID: string;
+  walletAddress: string;
+  avatarUrl: string;
+  displayName: string;
+  bio: string;
+  jobTitle: string;
+  primarySkill: string;
+  networkingStatus: string;
+  location: string;
+  channels: {
+    type: string;
+    isVerified: boolean;
+    isLocked: boolean;
+    value: string;
+    url: string;
+    metadata?: {
+      name: string;
+      value: string;
+    }[];
+  }[];
+  credentials: {
+    name: string;
+    chain: string;
+    source: string;
+    reference: string;
+  }[];
+  highlights: string[];
+  workExperience: string[];
+  events: {
+    id: string;
+    source: string;
+    city: string;
+    country: string;
+    description: string;
+    endDate: string;
+    eventUrl: string;
+    expiryDate: string;
+    imageUrl: string;
+    name: string;
+    startDate: string;
+    year: string;
+  }[];
+  guilds: {
+    guildId: number;
+    joinedAt: string;
+    roleIds: number[];
+    isAdmin: boolean;
+    isOwner: boolean;
+  }[];
+};
+
 export type IcebreakerStoreCredentialsParams = {
   schemaID?: string;
   attesterPKID?: string;

--- a/recbot/app/lib/utils.ts
+++ b/recbot/app/lib/utils.ts
@@ -16,3 +16,16 @@ export const getEthAddressForUser = (user: User) => {
     return user.custody_address;
   }
 };
+
+export const getIcebreakerUserFromFCUser = async (fname: string) => {
+  if (fname) {
+    const response = await fetch(`${ICEBREAKER_API_URL}/api/fname?fname=${fname}`);
+    if (!response.ok) {
+      throw new Error('Error fetching data for fname');
+    }
+    const json = await response.json();
+    return json.profiles[0];
+  } else {
+    throw new Error('No fname or fid for the user provided');
+  }
+};

--- a/recbot/app/lib/webhook.ts
+++ b/recbot/app/lib/webhook.ts
@@ -11,7 +11,7 @@ import {
 import { attestationsAndSkills, isValidSkill } from './attestation-matcher';
 
 export async function extractEndorsementFromCast(webhook: WebhookData) {
-  const skillResp = isValidSkill(
+  const skillResp = await isValidSkill(
     webhook.data.text,
     webhook.data.mentioned_profiles
   );


### PR DESCRIPTION
This PR adds a function called `hasCredential`, which is called in `isValidSkill` and is used to check if the user indeed has the skill/credential that they want to endorse someone else with. The PR also adds a function called `getIcebreakerUserFromFCUser`, which is called right before `hasCredential` and grabs the user's profile(which has their credentials) from the Icebreaker API(which we proxy behind a Next.js API route)