### PR TITLE
feat: add support for external gated credentials

### DIFF
--- a/recbot/app/lib/types.d.ts
+++ b/recbot/app/lib/types.d.ts
@@ -7,6 +7,7 @@ export type AttestationSchema = {
   name: string;
   isOpen: boolean;
   allowRecursion: boolean;
+  requiredSchemaName?: string;
 };
 
 export type IcebreakerChannel = {


### PR DESCRIPTION
- Updates `canFnameAttestToSchema` function with ability to support required schemas that do not match the existing one
- Adds support for Feather Ice