### PR TITLE
fix: allow for text after the `@rec @username Skill` RegExp for `recbot`

### DIFF
--- a/recbot/app/lib/attestation-matcher.ts
+++ b/recbot/app/lib/attestation-matcher.ts
@@ -147,7 +147,7 @@ export const isValidRec = async (
   authorFname: string
 ) => {
   const botUsername = 'rec';
-  const match = text.match(new RegExp(`^@${botUsername} \\S+ (.+)$`));
+  const match = text.match(new RegExp(`^@${botUsername} \\S+ \\S+ (.+?)(?:\\s+.*)?$`));
   const mentionedUsernames = mentioned_profiles
     .map((profile) => profile.username)
     .filter((username) => username !== 'rec');

--- a/recbot/app/lib/attestation-matcher.ts
+++ b/recbot/app/lib/attestation-matcher.ts
@@ -153,22 +153,22 @@ export const isValidRec = async (
   authorFname: string
 ) => {
   const botUsername = 'rec';
-  const match = text.match(new RegExp(`^@${botUsername} \\S+ \\S+ (.+?)(?:\\s+.*)?$`));
+  const match = text.match(new RegExp(`^@${botUsername} @(\\S+) (.+)$`));
   const mentionedUsernames = mentioned_profiles
     .map((profile) => profile.username)
     .filter((username) => username !== 'rec');
 
-  const recContent = match ? match[1] : '';
   const fname = mentionedUsernames[0];
+  const recContent = match ? match[2] : '';
   const matchedSchema = attestationsSchemas.find(
-    (schema) => schema.name === recContent
+    (schema) => recContent.includes(schema.name)
   );
 
   if (matchedSchema) {
     const isValid = await canFnameAttestToSchema(authorFname, matchedSchema);
     const returnObj = {
       mentionedUsername: fname,
-      schemaName: recContent,
+      schemaName: matchedSchema.name,
       isValid,
     };
     return returnObj;


### PR DESCRIPTION
edits the RegExp to be a bit more permissive so there can be text after the command, and instead searches for the skill as an exact match in the response string.

two working examples:
https://warpcast.com/dylsteck.eth/0x0ef1b4a2
https://warpcast.com/dylsteck.eth/0xf65c07c6