### PR TITLE
feat: add llm schema lookup fallback

### DIFF
--- a/recbot/app/lib/getLlmSchema.ts
+++ b/recbot/app/lib/getLlmSchema.ts
@@ -1,0 +1,29 @@
+const RAILWAY_API_URL = process.env.ICEBREAKER_AGENT_API_ENDPOINT;
+
+type LLMResponse = string | { schemaName: string };
+
+export async function getLLMSchema(text: string) {
+  if (!RAILWAY_API_URL) {
+    throw new Error('ICEBREAKER_AGENT_API_ENDPOINT is not set');
+  }
+
+  try {
+    const response = await fetch(RAILWAY_API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ text }),
+    });
+    if (!response.ok) {
+      throw new Error(`API call failed with status: ${response.status}`);
+    }
+    const data: LLMResponse = await response.json();
+    if (typeof data === 'string') {
+      return;
+    }
+    return data.schemaName;
+  } catch (error) {
+    console.error('Error calling attestation schema API:', error);
+  }
+}

--- a/recbot/app/lib/getRecommendationData.ts
+++ b/recbot/app/lib/getRecommendationData.ts
@@ -46,7 +46,7 @@ export const getRecommendationData = async (
   if (!cleanText) {
     return { attesteeFname, schemaName: '', isValid: false };
   }
-  const matchedSchema = getSchema(cleanText);
+  const matchedSchema = await getSchema(cleanText);
 
   if (matchedSchema) {
     const isValid = await canFnameAttestToSchema(authorFname, matchedSchema);

--- a/recbot/app/lib/getSchema.ts
+++ b/recbot/app/lib/getSchema.ts
@@ -1,16 +1,22 @@
-import { type AttestationSchema } from './types';
 import { attestationSchemas } from './attestationSchemas';
+import { getLLMSchema } from './getLlmSchema';
 
-const ICE_CREAM_PATTERN = /^(🍦|ice\s*cream|icecream)/i;
-
-export function getSchema(cleanText: string): AttestationSchema | undefined {
-  // TODO: Add LLM lookup for fuzzy matching
-
-  return cleanText.startsWith('bot')
+export async function getSchema(cleanText: string) {
+  const matchedSchema = cleanText.startsWith('bot')
     ? attestationSchemas.find((schema) => schema.name === 'Feather Ice')
-    : ICE_CREAM_PATTERN.test(cleanText)
-    ? attestationSchemas.find((schema) => schema.name === 'Ice cream')
     : attestationSchemas.find((schema) =>
         cleanText.includes(schema.name.toLowerCase())
       );
+
+  if (matchedSchema) {
+    return matchedSchema;
+  }
+
+  const llmSchema = await getLLMSchema(cleanText);
+
+  if (llmSchema) {
+    return attestationSchemas.find(
+      (schema) => schema.name.toLowerCase() === llmSchema.toLowerCase()
+    );
+  }
 }


### PR DESCRIPTION
- Adds new logic to fallback to LLM lookup when no clean mapping to schema exists
- Adds llm lookup using icebreaker agent
- TODO: Extract entire attestee and schema to LLM lookup